### PR TITLE
refactor(routing): use express routers

### DIFF
--- a/config/routes.js
+++ b/config/routes.js
@@ -1,25 +1,11 @@
 
-var passport     = require('passport'),
-  auth           = require('./../middlewares/auth'),
-  home           = require('./../controllers/home'),
+var home         = require('./../controllers/home'),
   authentication = require('./../controllers/authentication'),
   articles       = require('./../controllers/articles');
 
 module.exports = function (app) {
-  app.get('/', home.index);
-
-  app.get('/drafts', auth.requireLogin, articles.drafts);
-  app.get('/article/:slug', articles.view);
-  app.get('/article/edit/new', auth.requireLogin, articles.edit);
-  app.get('/article/edit/:slug', auth.requireLogin, articles.edit);
-  app.post('/article/edit', auth.requireLogin, articles.save);
-
-
-  app.get('/admin/login', authentication.login);
-  app.post('/admin/login', passport.authenticate('local', {
-    successRedirect: '/',
-    failureRedirect: '/admin/login',
-    failureFlash: true
-  }));
-  app.get('/admin/logout', auth.requireLogin, authentication.logout);
+  // setup controllers routers
+  app.use(home);
+  app.use(articles);
+  app.use(authentication);
 };

--- a/controllers/articles.js
+++ b/controllers/articles.js
@@ -1,9 +1,24 @@
 
 var mongoose  = require('mongoose'),
-  moment    = require('moment'),
-  Article   = mongoose.model('Article');
+  moment      = require('moment'),
+  Article     = mongoose.model('Article'),
+  passport    = require('passport'),
+  express     = require('express'),
+  auth        = require('./../middlewares/auth');
 
-exports.view = function (req, res) {
+module.exports = (function () {
+  var router = express.Router();
+
+  router.get('/drafts', auth.requireLogin, drafts);
+  router.get('/article/:slug', view);
+  router.get('/article/edit/new', auth.requireLogin, edit);
+  router.get('/article/edit/:slug', auth.requireLogin, edit);
+  router.post('/article/edit', auth.requireLogin, save);
+
+  return router;
+})();
+
+function view(req, res) {
   Article.findOne({slug: req.params.slug}, function (err, article) {
     if (err) {
       throw err;
@@ -15,9 +30,9 @@ exports.view = function (req, res) {
       article: article
     });
   });
-};
+}
 
-exports.drafts = function (req, res) {
+function drafts(req, res) {
   Article.find({})
     .sort('-createdAt')
     .where('published').ne(true)
@@ -30,9 +45,7 @@ exports.drafts = function (req, res) {
         articles: articles
       });
     });
-};
-
-
+}
 
 function edit(req, res) {
   if (req.params.slug && req.params.slug !== '') {

--- a/controllers/authentication.js
+++ b/controllers/authentication.js
@@ -1,10 +1,36 @@
 
-exports.login = function (req, res) {
-  res.render('users/login');
-};
+var passport = require('passport'),
+  express    = require('express'),
+  auth       = require('./../middlewares/auth');
 
-exports.logout = function (req, res) {
+module.exports = (function () {
+  var router = express.Router();
+
+  router.route('/admin/login')
+      .get(login)
+      .post(passport.authenticate('local', {
+        successRedirect: '/',
+        failureRedirect: '/admin/login',
+        failureFlash: true
+      }));
+
+  router.get('/admin/logout', auth.requireLogin, logout);
+
+  return router;
+})();
+
+function login(req, res) {
+  res.render('users/login');
+}
+
+function logout(req, res) {
   req.logout();
 
   res.redirect('/');
-};
+}
+
+var authenticate = passport.authenticate('local', {
+  successRedirect: '/',
+  failureRedirect: '/admin/login',
+  failureFlash: true
+});

--- a/controllers/home.js
+++ b/controllers/home.js
@@ -1,8 +1,19 @@
 
 var mongoose = require('mongoose'),
-    Article    = mongoose.model('Article');
+  Article    = mongoose.model('Article'),
+  passport   = require('passport'),
+  express    = require('express'),
+  auth       = require('./../middlewares/auth');
 
-exports.index = function (req, res) {
+module.exports = (function () {
+  var router = express.Router();
+
+  router.get('/', index);
+
+  return router;
+})();
+
+function index(req, res) {
   var limit = req.query.per_page || 10,
     page    = req.query.page || 0,
     skip    = page * limit;


### PR DESCRIPTION
Previously controllers exposed a set of methods (views handlers) which were registered in config/routes.js. Now, controllers simply export a express.Router object which is registered to express. This will allow unit tests for controllers and enhance code modularity.
